### PR TITLE
Move to alpine:3.12 and add support for email

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12.0
+FROM alpine:3.12
 
 ARG LUFI_VERSION=master
 

--- a/lufi.conf.template
+++ b/lufi.conf.template
@@ -137,15 +137,15 @@
     # Mail configuration
     # See https://metacpan.org/pod/Mojolicious::Plugin::Mail#EXAMPLES
     # optional, default to sendmail method with no arguments
-    #mail => {
-    #    # Valid values are 'sendmail' and 'smtp'
-    #    how => 'smtp',
-    #    howargs => ['smtp.example.org']
-    #},
+    mail => {
+        # Valid values are 'sendmail' and 'smtp'
+        how => '<mail_how>',
+        howargs => ['<mail_howargs>']
+    },
 
     # Email sender address
     # optional, default to no-reply@lufi.io
-    #mail_sender => 'no-reply@lufi.io',
+    mail_sender => '<mail_sender>',
 
     #############
     # DB settings

--- a/startup
+++ b/startup
@@ -17,6 +17,10 @@ if [ ! -e "${LUFI_DIR}/lufi.conf" ]; then
             -e 's|<default_delay>|'${DEFAULT_DELAY:-1}'|' \
             -e 's|<max_delay>|'${MAX_DELAY:-0}'|' \
             -e 's|<theme>|'${THEME:-default}'|' \
+            -e 's|<mail_sender>|'${MAIL_SENDER}'|' \
+            -e 's|<mail_how>|'${MAIL_HOW}'|' \
+            -e 's|<mail_howargs>|'${MAIL_HOWARGS}'|' \
+            -e 's|<report>|'${REPORT}'|' \
             -e 's|<allow_pwd_on_files>|'${ALLOW_PWD_ON_FILES:-1}'|' \
             -e 's|<policy_when_full>|'${POLICY_WHEN_FULL:-warn}'|' ${LUFI_DIR}/lufi.conf.template
     )" > ${LUFI_DIR}/lufi.conf


### PR DESCRIPTION
It should not be an issue to tag it the alpine major version.  Add support to send emails with links.